### PR TITLE
Switching cross entropy images

### DIFF
--- a/posts/2015-09-Visual-Information/index.html
+++ b/posts/2015-09-Visual-Information/index.html
@@ -302,11 +302,11 @@
 <p>Cross-entropy isn’t symmetric.</p>
 <p>So, why should you care about cross-entropy? Well, cross-entropy gives us a way to express how different two probability distributions are. The more different the distributions <span class="math">\(p\)</span> and <span class="math">\(q\)</span> are, the more the cross-entropy of <span class="math">\(p\)</span> with respect to <span class="math">\(q\)</span> will be bigger than the entropy of <span class="math">\(p\)</span>.</p>
 <div style="width:30%; margin-left:auto; margin-right:auto; margin-bottom:20px; margin-top:20px;">
-<img src="img/CrossEntropyPQ.png" alt>
+<img src="img/CrossEntropyQP.png" alt>
 </div>
 <p>Similarly, the more different <span class="math">\(p\)</span> is from <span class="math">\(q\)</span>, the more the cross-entropy of <span class="math">\(q\)</span> with respect to <span class="math">\(p\)</span> will be bigger than the entropy of <span class="math">\(q\)</span>.</p>
 <div style="width:30%; margin-left:auto; margin-right:auto; margin-bottom:20px; margin-top:20px;">
-<img src="img/CrossEntropyQP.png" alt>
+<img src="img/CrossEntropyPQ.png" alt>
 </div>
 <p>The really interesting thing is the difference between the entropy and the cross-entropy. That difference is how much longer our messages are because we used a code optimized for a different distribution. If the distributions are the same, this difference will be zero. As the difference grows, it will get bigger.</p>
 <p>We call this difference the Kullback–Leibler divergence, or just the KL divergence. The KL divergence of <span class="math">\(p\)</span> with respect to <span class="math">\(q\)</span>, <span class="math">\(D_q(p)\)</span>,<a href="#fn5" class="footnoteRef" id="fnref5"><sup>5</sup></a> is defined:<a href="#fn6" class="footnoteRef" id="fnref6"><sup>6</sup></a></p>


### PR DESCRIPTION
Hey Christopher,

In your article [_Visual Information Theory_](http://colah.github.io/posts/2015-09-Visual-Information/), you set up the Kullback–Leibler divergence just before [footnote reference five](http://colah.github.io/posts/2015-09-Visual-Information/#fnref5).  I believe you've switched the two images when showing the difference between the entropy of p and the cross entropy of p with respect to q and vice versa.  I've switched them.

Amazing blog by the way.  I came across it while reading through the TensorFlow tutorial and plan to go through all of your posts.  You have a great way of explaining things in an intuitive manner!  Thanks for all of the hard work you've put into it.